### PR TITLE
 Upgrades AdGuard Home to v0.92 hotfix 2

### DIFF
--- a/adguard/Dockerfile
+++ b/adguard/Dockerfile
@@ -21,7 +21,7 @@ RUN \
     \
     && mkdir /opt \
     && curl -L -s \
-        "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.92-hotfix1/AdGuardHome_v0.92-hotfix1_linux_${ARCH}.tar.gz" \
+        "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.92-hotfix2/AdGuardHome_v0.92-hotfix2_linux_${ARCH}.tar.gz" \
         | tar zxvf - -C /opt/ \
     && chmod a+x /opt/AdGuardHome/AdGuardHome
 


### PR DESCRIPTION
# Proposed Changes

Upgrades AdGuard Home to [v0.92 hotfix 2](https://github.com/AdguardTeam/AdGuardHome/releases/tag/v0.92-hotfix2). The only change is that AGH now additionally listens to TCP alongside with UDP: #521.

## Related Issues

It appears that v0.92 messed with the Netflix app (see #534 and #521), so we had to release one more hotfix. Hopefully, this one is the last and there will be no other problems with v0.92.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/