### PR TITLE
⬆️ Upgrades AdGuard Home to v0.94

### DIFF
--- a/adguard/Dockerfile
+++ b/adguard/Dockerfile
@@ -21,7 +21,7 @@ RUN \
     && if [[ "${BUILD_ARCH}" = "i386" ]]; then ARCH="386"; fi \
     \
     && curl -L -s \
-        "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.93/AdGuardHome_v0.93_linux_${ARCH}.tar.gz" \
+        "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.94/AdGuardHome_v0.94_linux_${ARCH}.tar.gz" \
         | tar zxvf - -C /opt/ \
     && chmod a+x /opt/AdGuardHome/AdGuardHome
 


### PR DESCRIPTION
# Proposed Changes

Upgrades AdGuard Home to [v0.94](https://github.com/AdguardTeam/AdGuardHome/releases/tag/v0.94)

- User-friendly client name -- using hosts file
- Parallel DNS Resolution
- Ability to set upstream DNS per domain/TLD
- Built-in DHCP server bugs
- Other improvements and bugfixes