### PR TITLE
Change panel_icon

### DIFF
--- a/adguard/config.json
+++ b/adguard/config.json
@@ -7,7 +7,7 @@
   "webui": "[PROTO:ssl]://[HOST]:[PORT:80]",
   "ingress": true,
   "ingress_port": 0,
-  "panel_icon": "mdi:block-helper",
+  "panel_icon": "mdi:shield-check",
   "startup": "services",
   "homeassistant": "0.92.0b2",
   "arch": [


### PR DESCRIPTION
# Proposed Changes

Change the panel_icon to shield-check which is pretty similar to the AdGuard Home logo.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/