### PR TITLE
Use --no-check-update flag

### DIFF
--- a/adguard/rootfs/etc/services.d/adguard/run
+++ b/adguard/rootfs/etc/services.d/adguard/run
@@ -10,6 +10,7 @@ bashio::log.info "Starting AdGuard Home server..."
 options+=(--port 45158)
 options+=(--host 127.0.0.1)
 options+=(--config data/AdGuardHome.yaml)
+options+=(--no-check-update)
 
 if bashio::debug; then
     option+=(--verbose)


### PR DESCRIPTION
# Proposed Changes

AdGuard Home 0.96 introduced a built-in update function.
However, because this is an add-on, updates are handled differently. Adding this flag disables the update checks.
https://github.com/hassio-addons/addon-adguard-home/pull/17 needs to be merged for this option to make sense.

## Related Issues

NA