### PR TITLE
⬆️ Upgrade AdGuard Home to v0.97.0

### DIFF
--- a/adguard/Dockerfile
+++ b/adguard/Dockerfile
@@ -21,7 +21,7 @@ RUN \
     && if [[ "${BUILD_ARCH}" = "i386" ]]; then ARCH="386"; fi \
     \
     && curl -L -s \
-        "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.96-hotfix/AdGuardHome_linux_${ARCH}.tar.gz" \
+        "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.97.0/AdGuardHome_linux_${ARCH}.tar.gz" \
         | tar zxvf - -C /opt/ \
     && chmod a+x /opt/AdGuardHome/AdGuardHome \
     \


### PR DESCRIPTION
# Proposed Changes

https://github.com/AdguardTeam/AdGuardHome/releases/tag/v0.97.0

<blockquote><img src="https://avatars1.githubusercontent.com/u/8361145?s=400&v=4" width="48" align="right"><div><img src="https://github.githubassets.com/favicon.ico" height="14"> GitHub</div><div><strong><a href="https://github.com/AdguardTeam/AdGuardHome">AdguardTeam/AdGuardHome</a></strong></div><div>Network-wide ads & trackers blocking DNS server. Contribute to AdguardTeam/AdGuardHome development by creating an account on GitHub.</div></blockquote>