### PR TITLE
⬆️ Upgrade AdGuard Home to v0.98.1

### DIFF
--- a/adguard/Dockerfile
+++ b/adguard/Dockerfile
@@ -21,7 +21,7 @@ RUN \
     && if [[ "${BUILD_ARCH}" = "i386" ]]; then ARCH="386"; fi \
     \
     && curl -L -s \
-        "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.97.1/AdGuardHome_linux_${ARCH}.tar.gz" \
+        "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.98.1/AdGuardHome_linux_${ARCH}.tar.gz" \
         | tar zxvf - -C /opt/ \
     && chmod a+x /opt/AdGuardHome/AdGuardHome \
     \

--- a/adguard/rootfs/etc/services.d/adguard/run
+++ b/adguard/rootfs/etc/services.d/adguard/run
@@ -10,6 +10,7 @@ bashio::log.info "Starting AdGuard Home server..."
 options+=(--port 45158)
 options+=(--host 127.0.0.1)
 options+=(--config data/AdGuardHome.yaml)
+options+=(--workdir /data/adguard)
 options+=(--no-check-update)
 
 if bashio::debug; then


### PR DESCRIPTION
# Proposed Changes

The 0.98.0 release:
https://github.com/AdguardTeam/AdGuardHome/releases/tag/v0.98.0

and as if it's a tradition a 0.0.1 hotfix:
https://github.com/AdguardTeam/AdGuardHome/releases/tag/v0.98.1

Fixes #31 as well 🎉 

<blockquote><img src="https://avatars1.githubusercontent.com/u/8361145?s=400&v=4" width="48" align="right"><div><img src="https://github.githubassets.com/favicon.ico" height="14"> GitHub</div><div><strong><a href="https://github.com/AdguardTeam/AdGuardHome">AdguardTeam/AdGuardHome</a></strong></div><div>Network-wide ads & trackers blocking DNS server. Contribute to AdguardTeam/AdGuardHome development by creating an account on GitHub.</div></blockquote>
<blockquote><img src="https://avatars1.githubusercontent.com/u/8361145?s=400&v=4" width="48" align="right"><div><img src="https://github.githubassets.com/favicon.ico" height="14"> GitHub</div><div><strong><a href="https://github.com/AdguardTeam/AdGuardHome">AdguardTeam/AdGuardHome</a></strong></div><div>Network-wide ads & trackers blocking DNS server. Contribute to AdguardTeam/AdGuardHome development by creating an account on GitHub.</div></blockquote>