### PR TITLE
🔨 Disable ipv6 by default for new installs

### DIFF
--- a/adguard/rootfs/etc/adguard/AdGuardHome.yaml
+++ b/adguard/rootfs/etc/adguard/AdGuardHome.yaml
@@ -1,3 +1,4 @@
 dns:
   port: 53
   bootstrap_dns: 1.1.1.1:53
+  aaaa_disabled: true


### PR DESCRIPTION
# Proposed Changes

As HassOS doesn't support IPv6, should we disable ipv6 queries by default for new installs?
Appreciate it will not impact existing

