### PR TITLE
🔨 Force disable SSL redirect

### DIFF
--- a/adguard/rootfs/etc/cont-init.d/adguard.sh
+++ b/adguard/rootfs/etc/cont-init.d/adguard.sh
@@ -15,3 +15,5 @@ port=$(bashio::addon.port "53/udp")
 yq write --inplace "${CONFIG}" \
     'dns.port' "${port}" \
     || hass.die 'Failed updating AdGuardHome DNS port'
+
+sed -i "s#force_https: true#force_https: false#g" $CONFIG


### PR DESCRIPTION
# Proposed Changes

Setting the following causes the Adguard UI to listen on 443:

![image](https://user-images.githubusercontent.com/24625998/83209148-99895e80-a125-11ea-8563-37d2d4239848.png)

This causes the UI to be non responsive, as it is already covered by Nginx/Ingress for SSL, should we force disable it.

Other thoughts, apart from HA auth, should we just remove Nginx?

## Related Issues

#64 