### PR TITLE
🔨 Configure Adguard port/protocol dynamically on startup

### DIFF
--- a/adguard/DOCS.md
+++ b/adguard/DOCS.md
@@ -85,6 +85,14 @@ authentication on the AdGuard Home by setting it to `true`.
 **Note**: _We STRONGLY suggest, not to use this, even if this add-on is
 only exposed to your internal network. USE AT YOUR OWN RISK!_
 
+## Encryption Settings (Advanced Usage)
+
+Adguard allows the configuration of running DNS-over-HTTPS and DNS-over-
+TLS locally. If you configure these options please ensure to restart the
+addon afterwards.  Also to use DNS-over-HTTPS correctly please ensure to
+configure SSL on the addon as well as in Adguard itself.  Also consider
+that the addon and Adguard cannot use the same port for SSL.
+
 ## Changelog & Releases
 
 This repository keeps a change log using [GitHub's releases][releases]

--- a/adguard/rootfs/etc/nginx/includes/upstream.conf
+++ b/adguard/rootfs/etc/nginx/includes/upstream.conf
@@ -1,3 +1,3 @@
 upstream backend {
-    server 127.0.0.1:45158;
+    server 127.0.0.1:%%port%%;
 }

--- a/adguard/rootfs/etc/nginx/servers/direct-ssl.disabled
+++ b/adguard/rootfs/etc/nginx/servers/direct-ssl.disabled
@@ -10,6 +10,7 @@ server {
 
     location / {
         access_by_lua_file /etc/nginx/lua/ha-auth.lua;
-        proxy_pass http://backend;
+        proxy_pass %%protocol%%://backend;
+    }
     }
 }

--- a/adguard/rootfs/etc/nginx/servers/direct-ssl.disabled
+++ b/adguard/rootfs/etc/nginx/servers/direct-ssl.disabled
@@ -12,5 +12,9 @@ server {
         access_by_lua_file /etc/nginx/lua/ha-auth.lua;
         proxy_pass %%protocol%%://backend;
     }
+
+    location /dns-query {
+        proxy_pass %%protocol%%://backend;
     }
+
 }

--- a/adguard/rootfs/etc/nginx/servers/direct.disabled
+++ b/adguard/rootfs/etc/nginx/servers/direct.disabled
@@ -6,6 +6,6 @@ server {
 
     location / {
         access_by_lua_file /etc/nginx/lua/ha-auth.lua;
-        proxy_pass http://backend;
+        proxy_pass %%protocol%%://backend;
     }
 }

--- a/adguard/rootfs/etc/nginx/servers/ingress.conf
+++ b/adguard/rootfs/etc/nginx/servers/ingress.conf
@@ -8,6 +8,6 @@ server {
         allow   172.30.32.2;
         deny    all;
 
-        proxy_pass http://backend;
+        proxy_pass %%protocol%%://backend;
     }
 }


### PR DESCRIPTION
# Proposed Changes

Setting encryption up incorrectly can cause the UI to fail due to the nginx config.

- Read AdGuardHome.yaml to see if SSL is enabled
- Configure NGINX for both ingress and direct (if enabled) with protocol and ports
- Exclude DNS-over-HTTPS endpoint from lua auth

## Related Issues

None