### PR TITLE
🚑 Use armv7 release instead of arm on armv7 architectures

### DIFF
--- a/adguard/Dockerfile
+++ b/adguard/Dockerfile
@@ -20,7 +20,7 @@ RUN \
     && if [[ "${BUILD_ARCH}" = "aarch64" ]]; then ARCH="arm64"; fi \
     && if [[ "${BUILD_ARCH}" = "amd64" ]]; then ARCH="amd64"; fi \
     && if [[ "${BUILD_ARCH}" = "armhf" ]]; then ARCH="arm"; fi \
-    && if [[ "${BUILD_ARCH}" = "armv7" ]]; then ARCH="arm"; fi \
+    && if [[ "${BUILD_ARCH}" = "armv7" ]]; then ARCH="armv7"; fi \
     && if [[ "${BUILD_ARCH}" = "i386" ]]; then ARCH="386"; fi \
     \
     && curl -L -s \


### PR DESCRIPTION
# Proposed Changes

Hi  Franck,
first of all. Nice work with all the Home Assistant Addons.
I looked a bit into the Adguard-Version issue (https://github.com/hassio-addons/addon-adguard-home/issues/78). As you probably already know, there was a problem in AdGuardHome. So i opened an issue there and they already fixed it. (see https://github.com/AdguardTeam/AdGuardHome/issues/2097 )

While searching for the error i noticed, that you are using the binary for arm when the Build_Arch is armv7. I would suggest to use the ARMv7 binary. I forked your Project and changed it. It is working fine on my Raspberry Pi4. 
So please have a look at my pull request.
With  kind regards
Andreas


## Related Issues

https://github.com/hassio-addons/addon-adguard-home/issues/78
https://github.com/AdguardTeam/AdGuardHome/issues/2097

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/