### PR TITLE
Remove obsolete webui from configuration

### DIFF
--- a/adguard/config.json
+++ b/adguard/config.json
@@ -4,7 +4,6 @@
   "slug": "adguard",
   "description": "Network-wide ads & trackers blocking DNS server",
   "url": "https://github.com/hassio-addons/addon-adguard-home",
-  "webui": "[PROTO:ssl]://[HOST]:[PORT:80]",
   "ingress": true,
   "ingress_port": 0,
   "panel_icon": "mdi:shield-check",


### PR DESCRIPTION
# Proposed Changes

Since this add-on uses Ingress, the `webui` configuration option has no effect.