### PR TITLE
⬆️ Upgrades AdGuard Home to v0.105.0

### DIFF
--- a/adguard/Dockerfile
+++ b/adguard/Dockerfile
@@ -25,7 +25,7 @@ RUN \
     && if [[ "${BUILD_ARCH}" = "i386" ]]; then ARCH="386"; fi \
     \
     && curl -L -s \
-        "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.104.3/AdGuardHome_linux_${ARCH}.tar.gz" \
+        "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.105.0/AdGuardHome_linux_${ARCH}.tar.gz" \
         | tar zxvf - -C /opt/ \
     \
     && export GNUPGHOME="$(mktemp -d)" \


### PR DESCRIPTION
# Proposed Changes

Upgrades AdGuard Home to new stable Release v0.105.0: https://github.com/AdguardTeam/AdGuardHome/releases/tag/v0.105.0

## Related Issues

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


______

I try to build the images on my machine but I get `tar: invalid magic` errors from docker... But ~~I think~~ this is an issue on my end
