### PR TITLE
Add local DNS-over-HTTPS port map

### DIFF
--- a/adguard/DOCS.md
+++ b/adguard/DOCS.md
@@ -93,7 +93,8 @@ addon afterwards. Also to use DNS-over-HTTPS correctly please ensure to
 configure SSL on the addon as well as in Adguard itself. Also consider
 that the addon and Adguard cannot use the same port for SSL.
 
-To serve DNS-over-HTTPS locally, map port 853 in the addon configuration and enable in the AdGuard Settings:
+To serve DNS-over-HTTPS locally, map port 853 in the addon configuration
+and enable in the AdGuard Settings:
 
 | Setting | Value |
 | :- | :- |

--- a/adguard/DOCS.md
+++ b/adguard/DOCS.md
@@ -93,6 +93,15 @@ addon afterwards. Also to use DNS-over-HTTPS correctly please ensure to
 configure SSL on the addon as well as in Adguard itself. Also consider
 that the addon and Adguard cannot use the same port for SSL.
 
+To serve DNS-over-HTTPS locally, map port 853 in the addon configuration and enable in the AdGuard Settings:
+
+| Setting | Value |
+| :- | :- |
+| Set a certificates file path | `/ssl/fullchain.pem` |
+| Set a private key file | `/ssl/prifkey.pem` |
+| Enable Encryption | Enabled |
+| Redirect to HTTPS Automatically | Disabled |
+
 ## Changelog & Releases
 
 This repository keeps a change log using [GitHub's releases][releases]

--- a/adguard/config.json
+++ b/adguard/config.json
@@ -17,7 +17,7 @@
   },
   "ports_description": {
     "53/udp": "DNS server port",
-    "80/tcp": "Web interface (Not required for Ingress)"
+    "80/tcp": "Web interface (Not required for Ingress)",
     "853/tcp": "DNS over HTTPS (Local)"
   },
   "discovery": ["adguard"],

--- a/adguard/config.json
+++ b/adguard/config.json
@@ -13,7 +13,8 @@
   "init": false,
   "ports": {
     "53/udp": 53,
-    "80/tcp": null
+    "80/tcp": null,
+    "853/tcp": null
   },
   "ports_description": {
     "53/udp": "DNS server port",

--- a/adguard/config.json
+++ b/adguard/config.json
@@ -18,6 +18,7 @@
   "ports_description": {
     "53/udp": "DNS server port",
     "80/tcp": "Web interface (Not required for Ingress)"
+    "853/tcp": "DNS over HTTPS (Local)"
   },
   "discovery": ["adguard"],
   "auth_api": true,


### PR DESCRIPTION
# Proposed Changes

* Add port map for DNS-over-HTTP (tcp/853)
* Update docs to provide configuration

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
