### PR TITLE
⬆️ Upgrades AdGuard Home to v0.105.1

### DIFF
--- a/adguard/Dockerfile
+++ b/adguard/Dockerfile
@@ -25,7 +25,7 @@ RUN \
     && if [[ "${BUILD_ARCH}" = "i386" ]]; then ARCH="386"; fi \
     \
     && curl -L -s \
-        "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.105.0/AdGuardHome_linux_${ARCH}.tar.gz" \
+        "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.105.1/AdGuardHome_linux_${ARCH}.tar.gz" \
         | tar zxvf - -C /opt/ \
     \
     && export GNUPGHOME="$(mktemp -d)" \


### PR DESCRIPTION
# Proposed Changes

Upgrades AdGuard Home to v0.105.1 release

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
