### PR TITLE
🚑 Bind AdGuard Home to the default interface

### DIFF
--- a/adguard/rootfs/etc/adguard/AdGuardHome.yaml
+++ b/adguard/rootfs/etc/adguard/AdGuardHome.yaml
@@ -1,3 +1,4 @@
 dns:
+  bind_host: 127.0.0.1
   port: 53
   bootstrap_dns: 1.1.1.1:53

--- a/adguard/rootfs/etc/cont-init.d/adguard.sh
+++ b/adguard/rootfs/etc/cont-init.d/adguard.sh
@@ -5,6 +5,7 @@
 # ==============================================================================
 readonly CONFIG="/data/adguard/AdGuardHome.yaml"
 declare port
+declare host
 
 if ! bashio::fs.file_exists "${CONFIG}"; then
     mkdir -p /data/adguard
@@ -15,3 +16,8 @@ port=$(bashio::addon.port "53/udp")
 yq write --inplace "${CONFIG}" \
     'dns.port' "${port}" \
     || hass.exit.nok 'Failed updating AdGuardHome DNS port'
+
+host=$(bashio::network.ipv4_address)
+yq write --inplace "${CONFIG}" \
+    'dns.bind_host' "${host}" \
+    || hass.exit.nok 'Failed updating AdGuardHome host'


### PR DESCRIPTION
# Proposed Changes

This PR binds AdGuard Home DNS specifically to the main gateway interface.

Its current behavior is to bind to everything it can find, which can cause problems on systems that have the systemd resolver. Additionally, right now, it will also show all the bonded interfaces in the AdGuard Home frontend, which is confusing as well.

