### PR TITLE
:ambulance: Ensure the add-on has proper API access

### DIFF
--- a/adguard/config.json
+++ b/adguard/config.json
@@ -22,6 +22,8 @@
   "discovery": ["adguard"],
   "auth_api": true,
   "host_network": true,
+  "hassio_api": true,
+  "hassio_role": "manager",
   "map": ["ssl"],
   "options": {
     "ssl": true,


### PR DESCRIPTION
# Proposed Changes

Ensures the add-on has access to the network information of the Supervisor API (so it can configure AdGuard correctly).