### PR TITLE
🚑 Fix host configuration, remove netmask

### DIFF
--- a/adguard/rootfs/etc/cont-init.d/adguard.sh
+++ b/adguard/rootfs/etc/cont-init.d/adguard.sh
@@ -19,5 +19,5 @@ yq write --inplace "${CONFIG}" \
 
 host=$(bashio::network.ipv4_address)
 yq write --inplace "${CONFIG}" \
-    'dns.bind_host' "${host}" \
+    'dns.bind_host' "${host%/*}" \
     || hass.exit.nok 'Failed updating AdGuardHome host'


### PR DESCRIPTION
# Proposed Changes

The Supervisor returns the main gateway address including the netmask, however, AdGuard doesn't like that. This PR ensures the netmask part is removed before use.
