### PR TITLE
Exclude querylogs from snapshots

### DIFF
--- a/adguard/config.json
+++ b/adguard/config.json
@@ -36,5 +36,6 @@
     "certfile": "str",
     "keyfile": "str",
     "leave_front_door_open": "bool?"
-  }
+  },
+  "snapshot_exclude": ["*/adguard/data/querylog.json"]
 }


### PR DESCRIPTION
# Proposed Changes

Excludes AdGuard querylogs from the snapshots. It is data that is not the worst to lose and reduces the size of the snapshot for this add-on tremendously.
