### PR TITLE
Add support for multiple bind interfaces

### DIFF
--- a/adguard/rootfs/etc/adguard/AdGuardHome.yaml
+++ b/adguard/rootfs/etc/adguard/AdGuardHome.yaml
@@ -1,4 +1,3 @@
 dns:
-  bind_host: 127.0.0.1
   port: 53
   bootstrap_dns: 1.1.1.1:53

--- a/adguard/rootfs/etc/cont-init.d/adguard.sh
+++ b/adguard/rootfs/etc/cont-init.d/adguard.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/with-contenv bashio
+# shellcheck disable=SC2207
 # ==============================================================================
 # Home Assistant Community Add-on: AdGuard Home
 # Handles configuration
 # ==============================================================================
 readonly CONFIG="/data/adguard/AdGuardHome.yaml"
 declare port
-declare host
+declare -a hosts
 
 if ! bashio::fs.file_exists "${CONFIG}"; then
     mkdir -p /data/adguard
@@ -14,10 +15,19 @@ fi
 
 port=$(bashio::addon.port "53/udp")
 yq write --inplace "${CONFIG}" \
-    'dns.port' "${port}" \
-    || hass.exit.nok 'Failed updating AdGuardHome DNS port'
+    dns.port "${port}" \
+    || bashio::exit.nok 'Failed updating AdGuardHome DNS port'
 
-host=$(bashio::network.ipv4_address)
-yq write --inplace "${CONFIG}" \
-    'dns.bind_host' "${host%/*}" \
-    || hass.exit.nok 'Failed updating AdGuardHome host'
+# Clean up old interface bind formats
+yq delete --inplace "${CONFIG}" dns.bind_host
+yq delete --inplace "${CONFIG}" dns.bind_hosts
+
+hosts+=($(bashio::network.ipv4_address))
+hosts+=($(bashio::network.ipv6_address))
+hosts+=($(bashio::addon.ip_address))
+for host in "${hosts[@]}"; do
+    bashio::log.info "Adding ${host}"
+    yq write --inplace "${CONFIG}" \
+        dns.bind_hosts[+] "${host%/*}" \
+        || bashio::exit.nok 'Failed updating AdGuardHome host'
+done


### PR DESCRIPTION
# Proposed Changes

This PR adds support for binding to multiple interfaces for AdGuard.
It includes re-instating the main interface of the add-on, IPv6 and support for multiple IP addresses defined on a single interface.

fixes #133
closes #153
fixes #140
fixes #162
fixes #139
fixes #136
fixes #134
closes hassio-addons/addon-wireguard#86
