### PR TITLE
Handle AdGuard config schema upgrades for bind hosts

### DIFF
--- a/adguard/rootfs/etc/cont-init.d/adguard.sh
+++ b/adguard/rootfs/etc/cont-init.d/adguard.sh
@@ -22,20 +22,22 @@ yq write --inplace "${CONFIG}" \
 
 # Bump schema version in case this is an upgrade path
 schema_version=$(yq read "${CONFIG}" schema_version)
-if [[ "${schema_version}" -eq 7 ]]; then
-    # Clean up old interface bind formats
-    yq delete --inplace "${CONFIG}" dns.bind_host
-    yq write --inplace "${CONFIG}" schema_version 8
-fi
+if bashio::var.has_value "${schema_version}"; then
+    if [[ "${schema_version}" -eq 7 ]]; then
+        # Clean up old interface bind formats
+        yq delete --inplace "${CONFIG}" dns.bind_host
+        yq write --inplace "${CONFIG}" schema_version 8
+    fi
 
-# Warn if this is an upgrade from below schema version 7, skip further process
-if [[ "${schema_version}" -lt 7 ]]; then
-    bashio::warning
-    bashio::warning "AdGuard Home needs to update its configuration schema"
-    bashio::warning "you might need to restart he add-on once more to complete"
-    bashio::warning "the upgrade process."
-    bashio::warning
-    bashio::exit.ok
+    # Warn if this is an upgrade from below schema version 7, skip further process
+    if [[ "${schema_version}" -lt 7 ]]; then
+        bashio::warning
+        bashio::warning "AdGuard Home needs to update its configuration schema"
+        bashio::warning "you might need to restart he add-on once more to complete"
+        bashio::warning "the upgrade process."
+        bashio::warning
+        bashio::exit.ok
+    fi
 fi
 
 hosts+=($(bashio::network.ipv4_address))


### PR DESCRIPTION
# Proposed Changes

AdGuard handles its own configuration upgrades. However, so do we now 😬 

This PR ensures we are not inferring with AdGuard process and will only handle 1 of the schema steps (otherwise, we'll just back off).
