### PR TITLE
Fix interfaces with correctly configured multiple addresses

### DIFF
--- a/adguard/rootfs/etc/cont-init.d/adguard.sh
+++ b/adguard/rootfs/etc/cont-init.d/adguard.sh
@@ -43,14 +43,15 @@ fi
 
 # Get IPv4 address
 addresses=$(bashio::network.ipv4_address)
-hosts+=("${addresses% *}")
+hosts+=("${addresses%/*}")
 
 # Get IPv6 address
 addresses=$(bashio::network.ipv6_address)
-hosts+=("${addresses% *}")
+hosts+=("${addresses%/*}")
 
 # Get "hassio" network interface
-hosts+=($(bashio::addon.ip_address))
+addresses=$(bashio::addon.ip_address)
+hosts+=("${addresses%/*}")
 
 # Add interface to bind to, to AdGuard Home
 yq delete --inplace "${CONFIG}" dns.bind_hosts


### PR DESCRIPTION
# Proposed Changes

In case of actually correctly configured interface (e.g., IPv6 with local link, and such), there is a new line... so stripping the first with space, doesn't work.

This PR adjusts the behavior to grab the part until the first `/` occurrence. Just as pretty 😬 