### PR TITLE
Fix binding to local link addresses

### DIFF
--- a/adguard/rootfs/etc/cont-init.d/adguard.sh
+++ b/adguard/rootfs/etc/cont-init.d/adguard.sh
@@ -8,7 +8,9 @@ readonly CONFIG="/data/adguard/AdGuardHome.yaml"
 declare port
 declare schema_version
 declare -a hosts
-declare addresses
+declare part
+declare fd
+declare a2
 
 if ! bashio::fs.file_exists "${CONFIG}"; then
     mkdir -p /data/adguard


### PR DESCRIPTION
# Proposed Changes

Fix binding to local link addresses. AdGuard seems to have issues with is, see:

https://github.com/AdguardTeam/AdGuardHome/issues/2926

This PR skips all local link addresses found, as they generally don't add much value anyways...

fixes #174

Additionally, it now processes all IP addresses, so it fixes #177