### PR TITLE
Help OS users find NetworkManager settings

### DIFF
--- a/adguard/DOCS.md
+++ b/adguard/DOCS.md
@@ -16,7 +16,8 @@ comparison to installing any other Home Assistant add-on.
 1. **Ensure your Home Assistant device has a
    [static IP and static external DNS servers!](https://github.com/home-assistant/hassos/blob/dev/Documentation/network.md#static-ip)**
    This is important! You **WILL** end up having issues if you skip this step.
-   Also, please note, setting a fixed IP in your router is **NOT** static.
+   - Change this setting in Supervisor: [![Open your Home Assistant instance and show your Supervisor system information.](https://my.home-assistant.io/badges/supervisor_info.svg)](https://my.home-assistant.io/redirect/supervisor_info/) (_Host → IP Address → Change → IPv4 → Static_)
+   - Please note, setting a fixed IP in your router is **NOT** static.
 1. Search for the "AdGuard Home" add-on in the Supervisor add-on store and
    install it.
 1. Start the "AdGuard Home" add-on.

--- a/adguard/DOCS.md
+++ b/adguard/DOCS.md
@@ -16,7 +16,9 @@ comparison to installing any other Home Assistant add-on.
 1. **Ensure your Home Assistant device has a
    [static IP and static external DNS servers!](https://github.com/home-assistant/hassos/blob/dev/Documentation/network.md#static-ip)**
    This is important! You **WILL** end up having issues if you skip this step.
-   - Change this setting in Supervisor: [![Open your Home Assistant instance and show your Supervisor system information.](https://my.home-assistant.io/badges/supervisor_info.svg)](https://my.home-assistant.io/redirect/supervisor_info/) (_Host → IP Address → Change → IPv4 → Static_)
+   - Change this setting in Supervisor:
+     [![Open your Home Assistant instance and show your Supervisor system information.](https://my.home-assistant.io/badges/supervisor_info.svg)](https://my.home-assistant.io/redirect/supervisor_info/)
+     (_Host → IP Address → Change → IPv4 → Static_)
    - Please note, setting a fixed IP in your router is **NOT** static.
 1. Search for the "AdGuard Home" add-on in the Supervisor add-on store and
    install it.


### PR DESCRIPTION
# Proposed Changes

Just trying fellow OS users to find the settings, particularily as OS is the default recommended choice for HA.

## Background

I've been running HA OS without any issues while relying on _Configuration → General → Internal URL_ (via Advanced Mode) alone likely without having a static IP set in NetworkManager eventually leading to getting burned by some sertings/versions combo just as [some others reported](https://github.com/hassio-addons/addon-adguard-home/issues/195). This tiny change should hopefully help fellow OS users save some time before they dig deep into low-level NetworkManager config for no reason.

## Related Issues

https://github.com/hassio-addons/addon-adguard-home/issues/195
