### PR TITLE
🚑 Fix yq for the v4 syntax

### DIFF
--- a/adguard/rootfs/etc/cont-init.d/adguard.sh
+++ b/adguard/rootfs/etc/cont-init.d/adguard.sh
@@ -5,7 +5,6 @@
 # Handles configuration
 # ==============================================================================
 readonly CONFIG="/data/adguard/AdGuardHome.yaml"
-declare port
 declare schema_version
 declare -a hosts
 declare part


### PR DESCRIPTION
# Proposed Changes

`yq` moved to v4, which uses a completely different syntax.