### PR TITLE
🚑 Fix invalid IP address format in bind_hosts

### DIFF
--- a/adguard/rootfs/etc/cont-init.d/adguard.sh
+++ b/adguard/rootfs/etc/cont-init.d/adguard.sh
@@ -82,7 +82,7 @@ for host in "${hosts[@]}"; do
       fi
     fi
 
-    host="${host}" yq --inplace e \
+    host="${host%/*}" yq --inplace e \
       '.dns.bind_hosts += [env(host)]' "${CONFIG}" \
         || bashio::exit.nok 'Failed updating AdGuardHome host'
 done


### PR DESCRIPTION
# Proposed Changes

AdGuard doesn't like CIDR notations, this PR adjusts that.

## Related Issues

fixes #235