### PR TITLE
snapshot -> backup

### DIFF
--- a/adguard/config.json
+++ b/adguard/config.json
@@ -38,5 +38,5 @@
     "keyfile": "str",
     "leave_front_door_open": "bool?"
   },
-  "snapshot_exclude": ["*/adguard/data/querylog.json"]
+  "backup_exclude": ["*/adguard/data/querylog.json"]
 }


### PR DESCRIPTION
# Proposed Changes

Rename `snapshot` to `backup`.
See : https://developers.home-assistant.io/blog/2021/08/24/supervisor_update/

## Related Issues

