### PR TITLE
Bind on all interfaces

### DIFF
--- a/adguard/rootfs/etc/cont-init.d/adguard.sh
+++ b/adguard/rootfs/etc/cont-init.d/adguard.sh
@@ -6,6 +6,7 @@
 # ==============================================================================
 readonly CONFIG="/data/adguard/AdGuardHome.yaml"
 declare schema_version
+declare -a interfaces
 declare -a hosts
 declare part
 declare fd
@@ -48,8 +49,11 @@ else
 fi
 
 # Collect IP addresses
-hosts+=($(bashio::network.ipv4_address))
-hosts+=($(bashio::network.ipv6_address))
+interfaces+=($(bashio::network.interfaces))
+for interface in "${interfaces[@]}"; do
+    hosts+=($(bashio::network.ipv4_address ${interface}))
+    hosts+=($(bashio::network.ipv6_address ${interface}))
+done
 hosts+=($(bashio::addon.ip_address))
 
 # Add interface to bind to, to AdGuard Home

--- a/adguard/rootfs/etc/cont-init.d/adguard.sh
+++ b/adguard/rootfs/etc/cont-init.d/adguard.sh
@@ -51,8 +51,8 @@ fi
 # Collect IP addresses
 interfaces+=($(bashio::network.interfaces))
 for interface in "${interfaces[@]}"; do
-    hosts+=($(bashio::network.ipv4_address ${interface}))
-    hosts+=($(bashio::network.ipv6_address ${interface}))
+    hosts+=($(bashio::network.ipv4_address "${interface}"))
+    hosts+=($(bashio::network.ipv6_address "${interface}"))
 done
 hosts+=($(bashio::addon.ip_address))
 


### PR DESCRIPTION
# Proposed Changes

The proposed change enumerates all network interfaces and adds them to AdGuard Home config, instead of the default one only. See also related issue.

## Related Issues

#239 AddGuard Home add-on binds to one interface only

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
