### PR TITLE
🔨 Update backup_exclude for rotated query logs

### DIFF
--- a/adguard/config.yaml
+++ b/adguard/config.yaml
@@ -42,4 +42,4 @@ schema:
   keyfile: str
   leave_front_door_open: bool?
 backup_exclude:
-  - "*/adguard/data/querylog.json"
+  - "*/adguard/data/querylog.*"


### PR DESCRIPTION
# Proposed Changes

Adguard appears to rotate query logs by appending a number to the end (e.g. querylog.json.1).  Updating the backup exclude to match on these as well.


