### PR TITLE
:books: Fix broken link in documentation

### DIFF
--- a/adguard/DOCS.md
+++ b/adguard/DOCS.md
@@ -35,7 +35,7 @@ Home Assistant, by default, ships with the Community Add-ons store installed.
 However, if it is missing (for any reason), you can add it by clicking the
 button My button below.
 
-[!Add repository to your Home Assitant instance.][repository-badge]][repository]
+[![Add repository to your Home Assitant instance.][repository-badge]][repository]
 
 ## Configuration
 


### PR DESCRIPTION

# Proposed Changes

> Fix add to repository button
![image](https://user-images.githubusercontent.com/1622866/158485916-8de907d6-53ea-4249-9645-f0fe59607b65.png)


## Related Issues

-

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
