### PR TITLE
⬆️ Upgrades AdGuard Home to v0.107.11

### DIFF
--- a/adguard/Dockerfile
+++ b/adguard/Dockerfile
@@ -21,7 +21,7 @@ RUN \
     && if [[ "${BUILD_ARCH}" = "i386" ]]; then ARCH="386"; fi \
     \
     && curl -L -s \
-        "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.10/AdGuardHome_linux_${ARCH}.tar.gz" \
+        "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.11/AdGuardHome_linux_${ARCH}.tar.gz" \
         | tar zxvf - -C /opt/ \
     \
     && chmod a+x /opt/AdGuardHome/AdGuardHome \


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardHome/releases/tag/v0.107.11

likely closes #334, #336, #337