### PR TITLE
⬆️ Upgrades AdGuard Home to v0.107.26

### DIFF
--- a/adguard/Dockerfile
+++ b/adguard/Dockerfile
@@ -21,7 +21,7 @@ RUN \
     && if [[ "${BUILD_ARCH}" = "i386" ]]; then ARCH="386"; fi \
     \
     && curl -L -s \
-        "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.25/AdGuardHome_linux_${ARCH}.tar.gz" \
+        "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.26/AdGuardHome_linux_${ARCH}.tar.gz" \
         | tar zxvf - -C /opt/ \
     \
     && chmod a+x /opt/AdGuardHome/AdGuardHome \


### PR DESCRIPTION
* https://github.com/AdguardTeam/AdGuardHome/releases/tag/v0.107.26
* Security fix for [CVE-2023-24532](https://github.com/advisories/GHSA-x2w5-7wp4-5qff)