### PR TITLE
Drop support for armhf & i386

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,7 +11,7 @@
       "matchStringsStrategy": "any",
       "matchStrings": [
         "ARG BUILD_FROM=(?<depName>.*?):(?<currentValue>.*?)\\s+",
-        "(aarch64|amd64|armhf|armv7|i386):\\s[\"']?(?<depName>.*?):(?<currentValue>.*?)[\"']?\\s"
+        "(aarch64|amd64|armv7):\\s[\"']?(?<depName>.*?):(?<currentValue>.*?)[\"']?\\s"
       ],
       "datasourceTemplate": "docker"
     },

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ SOFTWARE.
 
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
-[armhf-shield]: https://img.shields.io/badge/armhf-yes-green.svg
+[armhf-shield]: https://img.shields.io/badge/armhf-no-red.svg
 [armv7-shield]: https://img.shields.io/badge/armv7-yes-green.svg
 [commits-shield]: https://img.shields.io/github/commit-activity/y/hassio-addons/addon-adguard-home.svg
 [commits]: https://github.com/hassio-addons/addon-adguard-home/commits/main
@@ -119,7 +119,7 @@ SOFTWARE.
 [github-actions]: https://github.com/hassio-addons/addon-adguard-home/actions
 [github-sponsors-shield]: https://frenck.dev/wp-content/uploads/2019/12/github_sponsor.png
 [github-sponsors]: https://github.com/sponsors/frenck
-[i386-shield]: https://img.shields.io/badge/i386-yes-green.svg
+[i386-shield]: https://img.shields.io/badge/i386-no-red.svg
 [issue]: https://github.com/hassio-addons/addon-adguard-home/issues
 [license-shield]: https://img.shields.io/github/license/hassio-addons/addon-adguard-home.svg
 [maintenance-shield]: https://img.shields.io/maintenance/yes/2023.svg

--- a/adguard/Dockerfile
+++ b/adguard/Dockerfile
@@ -17,9 +17,7 @@ RUN \
     \
     && if [[ "${BUILD_ARCH}" = "aarch64" ]]; then ARCH="arm64"; fi \
     && if [[ "${BUILD_ARCH}" = "amd64" ]]; then ARCH="amd64"; fi \
-    && if [[ "${BUILD_ARCH}" = "armhf" ]]; then ARCH="armv6"; fi \
     && if [[ "${BUILD_ARCH}" = "armv7" ]]; then ARCH="armv7"; fi \
-    && if [[ "${BUILD_ARCH}" = "i386" ]]; then ARCH="386"; fi \
     \
     && curl -L -s \
         "https://github.com/AdguardTeam/AdGuardHome/releases/download/${ADGUARD_HOME_VERSION}/AdGuardHome_linux_${ARCH}.tar.gz" \

--- a/adguard/build.yaml
+++ b/adguard/build.yaml
@@ -2,9 +2,7 @@
 build_from:
   aarch64: ghcr.io/hassio-addons/base:14.2.2
   amd64: ghcr.io/hassio-addons/base:14.2.2
-  armhf: ghcr.io/hassio-addons/base:14.2.2
   armv7: ghcr.io/hassio-addons/base:14.2.2
-  i386: ghcr.io/hassio-addons/base:14.2.2
 codenotary:
   base_image: codenotary@frenck.dev
   signer: codenotary@frenck.dev

--- a/adguard/config.yaml
+++ b/adguard/config.yaml
@@ -14,9 +14,7 @@ homeassistant: 0.113.2
 arch:
   - aarch64
   - amd64
-  - armhf
   - armv7
-  - i386
 init: false
 ports:
   53/udp: 53


### PR DESCRIPTION
# Proposed Changes

SSIA

The usage on these platforms is really, really low.
For that reason, we are no longer maintaining these architectures in the community add-ons project.

../Frenck
