### PR TITLE
Add NPM/Nginx Addon as Trusted Proxies by default / Update AdGuardHome.yaml

### DIFF
--- a/adguard/rootfs/etc/adguard/AdGuardHome.yaml
+++ b/adguard/rootfs/etc/adguard/AdGuardHome.yaml
@@ -1,3 +1,7 @@
 dns:
   port: 53
   bootstrap_dns: 1.1.1.1:53
+  trusted_proxies:
+    - 127.0.0.0/8
+    - ::1/128
+    - 172.30.33.0/24


### PR DESCRIPTION
# Proposed Changes

Add the 172.30.33.0/24 network to cover requests coming from official NPM/Nginx Addon as Trusted Proxies by default. This is necessary for client identification based on IP.

As specified in: https://github.com/AdguardTeam/AdGuardHome/wiki/Configuration trusted_proxies (since v0.107.0) – The list of IP addresses and CIDR prefixes of trusted HTTP proxy servers. If a DNS-over-HTTPS request comes from one of these addresses or networks, AdGuard Home uses the provided proxy headers, such as X-Real-IP, to get the real IP address of the client. Requests from HTTP proxies outside of these networks are considered to be requests from the proxy itself. That is, the proxy headers are ignored.

Prior to this
    - 127.0.0.0/8
    - ::1/128
were usually auto added as proxies during setup when no trusted proxy was specified. Since it is now specified those values are no longer auto added. To prevent problems if users are not using reverse proxies but access DoH directly via the native AdGuard https interface these values are now specified as well. This prevents breaking changes.

Tested.
Prior to this the trusted_proxies section in AdGuardHome.yaml looked like this:
```
  trusted_proxies:
    - 127.0.0.0/8
    - ::1/128
```

Now it looks like this:
```
  trusted_proxies:
    - 127.0.0.0/8
    - ::1/128
    - 172.30.33.0/24
```


## Related Issues

Fixes https://github.com/hassio-addons/addon-adguard-home/issues/467 
Partially related to https://github.com/hassio-addons/addon-adguard-home/issues/354
