### PR TITLE
Rewrite to support IPv6 Link Local addresses

### DIFF
--- a/adguard/rootfs/etc/s6-overlay/s6-rc.d/init-adguard/run
+++ b/adguard/rootfs/etc/s6-overlay/s6-rc.d/init-adguard/run
@@ -9,8 +9,6 @@ readonly CONFIG="/data/adguard/AdGuardHome.yaml"
 declare schema_version
 declare -a interfaces
 declare -a hosts
-declare -a hosts_v4
-declare -a hosts_v6
 declare part
 declare fd
 declare a2
@@ -54,13 +52,15 @@ fi
 # Collect IP addresses from interfaces
 interfaces+=($(bashio::network.interfaces))
 for interface in "${interfaces[@]}"; do
-    hosts_v4+=($(bashio::network.ipv4_address "${interface}"))
-    hosts_v6+=($(bashio::network.ipv6_address "${interface}"))
-    # Remove the netmask (for example /24) from the address
-    for host in "${hosts_v4[@]}"; do
+
+    # IPv4 addresses on the interface
+    for host in $(bashio::network.ipv4_address "${interface}"); do
+        # Remove the netmask (for example /24) from the address
         hosts+=("${host%/*}")
     done
-    for host in "${hosts_v6[@]}"; do
+
+    # IPv6 addresses on the interface
+    for host in $(bashio::network.ipv6_address "${interface}"); do
         part="${host%%:*}"
         # The decimal values for 0xfd & 0xa2
         fd=$(( (0x$part) / 256 ))
@@ -73,6 +73,7 @@ for interface in "${interfaces[@]}"; do
             hosts+=("${host%/*}")
         fi
     done
+
 done
 # Bind to addon ip address
 hosts+=($(bashio::addon.ip_address))

--- a/adguard/rootfs/etc/s6-overlay/s6-rc.d/init-adguard/run
+++ b/adguard/rootfs/etc/s6-overlay/s6-rc.d/init-adguard/run
@@ -75,7 +75,7 @@ for interface in "${interfaces[@]}"; do
     done
 
 done
-# Bind to addon ip address
+# Bind to addon IP address
 hosts+=($(bashio::addon.ip_address))
 # Bind to localhost ip addresses as well.
 hosts+=("127.0.0.1")

--- a/adguard/rootfs/etc/s6-overlay/s6-rc.d/init-adguard/run
+++ b/adguard/rootfs/etc/s6-overlay/s6-rc.d/init-adguard/run
@@ -9,6 +9,8 @@ readonly CONFIG="/data/adguard/AdGuardHome.yaml"
 declare schema_version
 declare -a interfaces
 declare -a hosts
+declare -a hosts_v4
+declare -a hosts_v6
 declare part
 declare fd
 declare a2
@@ -49,12 +51,30 @@ else
     yq --inplace e '.dns.bind_host = "127.0.0.1"' "${CONFIG}"
 fi
 
-# Collect IP addresses
+# Collect IP addresses from interfaces
 interfaces+=($(bashio::network.interfaces))
 for interface in "${interfaces[@]}"; do
-    hosts+=($(bashio::network.ipv4_address "${interface}"))
-    hosts+=($(bashio::network.ipv6_address "${interface}"))
+    hosts_v4+=($(bashio::network.ipv4_address "${interface}"))
+    hosts_v6+=($(bashio::network.ipv6_address "${interface}"))
+    # Remove the netmask (for example /24) from the address
+    for host in "${hosts_v4[@]}"; do
+        hosts+=("${host%/*}")
+    done
+    for host in "${hosts_v6[@]}"; do
+        part="${host%%:*}"
+        # The decimal values for 0xfd & 0xa2
+        fd=$(( (0x$part) / 256 ))
+        a2=$(( (0x$part) % 256 ))
+        # fe80::/10 according to RFC 4193 -> Local link. Add interface to bind to
+        if (( (fd == 254) && ( (a2 & 192) == 128) )); then
+            hosts+=("${host%/*}%${interface}")
+        else
+            # Remove the netmask (for example /64) from the address
+            hosts+=("${host%/*}")
+        fi
+    done
 done
+# Bind to addon ip address
 hosts+=($(bashio::addon.ip_address))
 # Bind to localhost ip addresses as well.
 hosts+=("127.0.0.1")
@@ -68,19 +88,8 @@ for host in "${hosts[@]}"; do
         continue
     fi
 
-    if [[ "${host}" =~ .*:.* ]]; then
-      # IPv6
-      part="${host%%:*}"
+    if [[ "${host}" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
 
-      # The decimal values for 0xfd & 0xa2
-      fd=$(( (0x$part) / 256 ))
-      a2=$(( (0x$part) % 256 ))
-
-      # fe80::/10 according to RFC 4193 -> Local link. Skip it
-      if (( (fd == 254) && ( (a2 & 192) == 128) )); then
-        continue
-      fi
-    else
       # IPv4
       part="${host%%.*}"
 
@@ -90,7 +99,7 @@ for host in "${hosts[@]}"; do
       fi
     fi
 
-    host="${host%/*}" yq --inplace e \
+    host="${host}" yq --inplace e \
       '.dns.bind_hosts += [env(host)]' "${CONFIG}" \
         || bashio::exit.nok 'Failed updating AdGuardHome host'
 done


### PR DESCRIPTION
# Proposed Changes

IPv6 Link Local Addresses (fe80) were skipped during the configuration of the interface binding. A use case could be to run your DNS server on address fe80::53 on all your networks. For this LLA should be supported.

For LLA binding, the interface name needs to be added to the binding. Like: fe80::53%enp1s0. I've rewritten the script to parse LLA with interface bindings.

This PR can be tested on my Dev repository:
https://github.com/erwin-willems/hassio-addons

## Related Issues

> #463 adguarhome add-on does not listen on ipv6 link-local address, and zerotier interface

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved IP address handling for both IPv4 and IPv6, ensuring more accurate and reliable network configurations.
  - Added support for binding to addon IP addresses and localhost IP addresses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->