### PR TITLE
fix: remove port from bootstrap DNS

### DIFF
--- a/adguard/rootfs/etc/adguard/AdGuardHome.yaml
+++ b/adguard/rootfs/etc/adguard/AdGuardHome.yaml
@@ -1,3 +1,3 @@
 dns:
   port: 53
-  bootstrap_dns: 1.1.1.1:53
+  bootstrap_dns: 1.1.1.1


### PR DESCRIPTION
This fixes a configuration parsing error.

# Proposed Changes

This commit removes the port specification from the default AdGuard home bootstrap DNS.

The current configuration generates a parsing error:

```
2024/03/11 11:55:36 [error] Couldn't get logging settings from the configuration: yaml: unmarshal errors:
  line 3: cannot unmarshal !!str `1.1.1.1:53` into []string
```

This commit fixes the error and allows AdGuard home to keep parsing its configuration.

## Related Issues

Fixes #499 
