### PR TITLE
Disable use of private reverse DNS servers by default

### DIFF
--- a/adguard/rootfs/etc/adguard/AdGuardHome.yaml
+++ b/adguard/rootfs/etc/adguard/AdGuardHome.yaml
@@ -1,3 +1,4 @@
 dns:
   port: 53
   bootstrap_dns: 1.1.1.1:53
+  use_private_ptr_resolvers: false


### PR DESCRIPTION

# Proposed Changes

Currently, the one picked is the Home Assistant internal DNS plug-in (CoreDNS server), which depending on configuration might lead to a DNS loop.

Users should configure explicitly a private reverse DNS server. Disable the feature by default.

## Related Issues

https://github.com/hassio-addons/addon-adguard-home/issues/501