### PR TITLE
Update adguard home to v0.107.52

### DIFF
--- a/adguard/Dockerfile
+++ b/adguard/Dockerfile
@@ -8,7 +8,7 @@ ARG BUILD_ARCH=amd64
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Setup base
-ARG ADGUARD_HOME_VERSION="v0.107.51"
+ARG ADGUARD_HOME_VERSION="v0.107.52"
 # hadolint ignore=DL3003,SC2155
 RUN \
     apk add --no-cache \


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardHome/releases/tag/v0.107.52

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated AdGuard Home to version "v0.107.52" for improved stability and new features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->