### PR TITLE
documentation: AdGuard add-on: Add client setting instructions

### DIFF
--- a/adguard/DOCS.md
+++ b/adguard/DOCS.md
@@ -30,6 +30,7 @@ comparison to installing any other Home Assistant add-on.
 1. Start the "AdGuard Home" add-on.
 1. Check the logs of the "AdGuard Home" to see if everything went well.
 1. Click the "OPEN WEB UI" button and log in with your Home Assistant account.
+1. If you have set your router to use the IP address of your Home Assistant as its DNS, you need to add the router's IP address as a client in AdGuard's settings under _Settings → Client settings_.
 1. Ready to go!
 
 ## Configuration


### PR DESCRIPTION
# Proposed Changes

Document the most common use case that [confuses many users](https://community.home-assistant.io/t/adguard-problem-not-working/407907) new to AdGuard.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the AdGuard Home add-on setup guide to include a new step. Users are now instructed to add their router’s IP as a client in AdGuard’s settings when using Home Assistant’s IP as the DNS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->