### PR TITLE
⬇️ Downgrade AdGuard Home to v0.107.64

### DIFF
--- a/adguard/Dockerfile
+++ b/adguard/Dockerfile
@@ -8,7 +8,7 @@ ARG BUILD_ARCH=amd64
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Setup base
-ARG ADGUARD_HOME_VERSION="v0.107.65"
+ARG ADGUARD_HOME_VERSION="v0.107.64"
 # hadolint ignore=DL3003,SC2155
 RUN \
     apk add --no-cache \


### PR DESCRIPTION
# Fix 401 Unauthorized errors when accessing control/profile by downgrading adguard to v0.107.64

## changes

Downgrade AdGuard Home to v0.107.64 to resolve 401 Unauthorized errors when accessing control/profile.

Upgrade yq-go from 4.46.1-r1 to 4.46.1-r2 to fix deployment issues encountered during testing.

## Related Issues

[https://github.com/hassio-addons/addon-adguard-home/issues/626](url)


[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated container default to AdGuard Home v0.107.64.

Impact:
* New container builds will use AdGuard Home v0.107.64 by default.
* No user interface changes expected; behavior aligns with the specified version.
* Users should rebuild or pull the updated image to apply the version change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->