### PR TITLE
Revert "⬇️ Downgrade AdGuard Home to v0.107.64"

### DIFF
--- a/adguard/Dockerfile
+++ b/adguard/Dockerfile
@@ -8,7 +8,7 @@ ARG BUILD_ARCH=amd64
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Setup base
-ARG ADGUARD_HOME_VERSION="v0.107.64"
+ARG ADGUARD_HOME_VERSION="v0.107.65"
 # hadolint ignore=DL3003,SC2155
 RUN \
     apk add --no-cache \


### PR DESCRIPTION
Reverts hassio-addons/addon-adguard-home#635

CC @ocueye2

The problem with the downgrade, is that it isn't backwards compatible with existing installs. Schemas have been migrated, causing AdGuard to crash on startup.

Seems like we have no other option than waiting for AdGuard to address the issue.

../Frenck

