### PR TITLE
Add support for Ports 443, 784, 853 & 2443

### DIFF
--- a/adguard/config.yaml
+++ b/adguard/config.yaml
@@ -19,9 +19,17 @@ init: false
 ports:
   53/udp: 53
   80/tcp: null
+  443/tcp: null
+  784/tcp: null
+  853/tcp: null
+  2443/tcp: null
 ports_description:
   53/udp: DNS server port
   80/tcp: Web interface (Not required for Ingress)
+  443/tcp: Web interface (Not required for Ingress)
+  784/tcp: DNS-over-QUIC
+  853/tcp: DNS-over-TLS
+  2443/tcp: DNS-over-HTTPS
 discovery:
   - adguard
 auth_api: true


### PR DESCRIPTION
# Proposed Changes
This PR adds the functunality to use the ports 443, 784, 853 & 2443 for Adguard Home. This will be needed to use these features: HTTPS Web, DNS-over-QUIC, DNS-over-TLS, DNS-over-HTTPS

This allows features like this: https://adguard.com/en/blog/adguard-home-on-public-server.html

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
