### PR TITLE
Drop support for armv7 systems

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,7 +12,7 @@
       "matchStringsStrategy": "any",
       "matchStrings": [
         "ARG BUILD_FROM=(?<depName>.*?):(?<currentValue>.*?)\\s+",
-        "(aarch64|amd64|armv7):\\s[\"']?(?<depName>.*?):(?<currentValue>.*?)[\"']?\\s"
+        "(aarch64|amd64):\\s[\"']?(?<depName>.*?):(?<currentValue>.*?)[\"']?\\s"
       ],
       "datasourceTemplate": "docker"
     },

--- a/README.md
+++ b/README.md
@@ -6,9 +6,6 @@
 
 ![Supports aarch64 Architecture][aarch64-shield]
 ![Supports amd64 Architecture][amd64-shield]
-![Supports armhf Architecture][armhf-shield]
-![Supports armv7 Architecture][armv7-shield]
-![Supports i386 Architecture][i386-shield]
 
 [![Github Actions][github-actions-shield]][github-actions]
 ![Project Maintenance][maintenance-shield]
@@ -102,8 +99,6 @@ SOFTWARE.
 
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
-[armhf-shield]: https://img.shields.io/badge/armhf-no-red.svg
-[armv7-shield]: https://img.shields.io/badge/armv7-yes-green.svg
 [commits-shield]: https://img.shields.io/github/commit-activity/y/hassio-addons/addon-adguard-home.svg
 [commits]: https://github.com/hassio-addons/addon-adguard-home/commits/main
 [contributors]: https://github.com/hassio-addons/addon-adguard-home/graphs/contributors
@@ -119,7 +114,6 @@ SOFTWARE.
 [github-actions]: https://github.com/hassio-addons/addon-adguard-home/actions
 [github-sponsors-shield]: https://frenck.dev/wp-content/uploads/2019/12/github_sponsor.png
 [github-sponsors]: https://github.com/sponsors/frenck
-[i386-shield]: https://img.shields.io/badge/i386-no-red.svg
 [issue]: https://github.com/hassio-addons/addon-adguard-home/issues
 [license-shield]: https://img.shields.io/github/license/hassio-addons/addon-adguard-home.svg
 [maintenance-shield]: https://img.shields.io/maintenance/yes/2025.svg

--- a/adguard/Dockerfile
+++ b/adguard/Dockerfile
@@ -17,7 +17,6 @@ RUN \
     \
     && if [[ "${BUILD_ARCH}" = "aarch64" ]]; then ARCH="arm64"; fi \
     && if [[ "${BUILD_ARCH}" = "amd64" ]]; then ARCH="amd64"; fi \
-    && if [[ "${BUILD_ARCH}" = "armv7" ]]; then ARCH="armv7"; fi \
     \
     && curl -L -s \
         "https://github.com/AdguardTeam/AdGuardHome/releases/download/${ADGUARD_HOME_VERSION}/AdGuardHome_linux_${ARCH}.tar.gz" \

--- a/adguard/build.yaml
+++ b/adguard/build.yaml
@@ -2,7 +2,6 @@
 build_from:
   aarch64: ghcr.io/hassio-addons/base:18.2.1
   amd64: ghcr.io/hassio-addons/base:18.2.1
-  armv7: ghcr.io/hassio-addons/base:18.2.1
 codenotary:
   base_image: codenotary@frenck.dev
   signer: codenotary@frenck.dev

--- a/adguard/config.yaml
+++ b/adguard/config.yaml
@@ -14,7 +14,6 @@ homeassistant: 0.113.2
 arch:
   - aarch64
   - amd64
-  - armv7
 init: false
 ports:
   53/udp: 53


### PR DESCRIPTION
# Proposed Changes

Support for `armv7` systems has been dropped, as they are deprecated by the Home Assistant project and scheduled for be fully dropped in the upcoming December release.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed support for armv7, armhf, and i386 architectures from build configurations, Docker build process, and dependency management settings. Removed corresponding armv7 ARCH variable mapping from Docker build instructions.

* **Documentation**
  * Updated README by removing architecture badges for discontinued armv7, armhf, and i386 platforms from all shield sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->