### PR TITLE
⬆️ Update to base image 21.0.0 (Alpine 3.24)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -26,7 +26,7 @@
       ],
       "versioningTemplate": "loose",
       "datasourceTemplate": "repology",
-      "depNameTemplate": "alpine_3_23/{{package}}"
+      "depNameTemplate": "alpine_3_24/{{package}}"
     },
     {
       "customType": "regex",

--- a/adguard/Dockerfile
+++ b/adguard/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=ghcr.io/hassio-addons/base:20.1.1
+ARG BUILD_FROM=ghcr.io/hassio-addons/base:21.0.0
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 
@@ -12,8 +12,8 @@ ARG ADGUARD_HOME_VERSION="v0.107.77"
 # hadolint ignore=DL3003,SC2155
 RUN \
     apk add --no-cache \
-        nginx=1.28.3-r2 \
-        yq-go=4.49.2-r6 \
+        nginx=1.30.2-r1 \
+        yq-go=4.53.3-r0 \
     \
     && if [[ "${BUILD_ARCH}" = "aarch64" ]]; then ARCH="arm64"; fi \
     && if [[ "${BUILD_ARCH}" = "amd64" ]]; then ARCH="amd64"; fi \

--- a/adguard/build.yaml
+++ b/adguard/build.yaml
@@ -1,4 +1,4 @@
 ---
 build_from:
-  aarch64: ghcr.io/hassio-addons/base:20.1.1
-  amd64: ghcr.io/hassio-addons/base:20.1.1
+  aarch64: ghcr.io/hassio-addons/base:21.0.0
+  amd64: ghcr.io/hassio-addons/base:21.0.0


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Updates the AdGuard Home add-on to the latest Home Assistant Community Add-ons base image `ghcr.io/hassio-addons/base:21.0.0`, which is based on Alpine 3.24, and refreshes the pinned `apk` packages to their latest versions for Alpine 3.24:

* `nginx` `1.28.3-r2` → `1.30.2-r1`
* `yq-go` `4.49.2-r6` → `4.53.3-r0`

The Renovate Repology versioning template was also updated from `alpine_3_23` to `alpine_3_24` so package updates continue to track the correct Alpine branch.

The image builds successfully with `docker build . --progress=plain --no-cache`.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated base container image to the latest version
  * Upgraded system package versions for enhanced stability and security
  * Updated build configuration for all supported platforms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->