### PR TITLE
📝 Fix AdGuard Home documentation issues

### DIFF
--- a/adguard/DOCS.md
+++ b/adguard/DOCS.md
@@ -56,6 +56,7 @@ dealing with an unknown issue. Possible values are:
 - `trace`: Show every detail, like all called internal functions.
 - `debug`: Shows detailed debug information.
 - `info`: Normal (usually) interesting events.
+- `notice`: Normal but significant events.
 - `warning`: Exceptional occurrences that are not errors.
 - `error`: Runtime errors that do not require immediate action.
 - `fatal`: Something went terribly wrong. App becomes unusable.
@@ -95,11 +96,11 @@ only exposed to your internal network. USE AT YOUR OWN RISK!_
 
 ## Encryption Settings (Advanced Usage)
 
-Adguard allows the configuration of running DNS-over-HTTPS and DNS-over-
-TLS locally. If you configure these options please ensure to restart the
-app afterwards. Also to use DNS-over-HTTPS correctly please ensure to
-configure SSL on the app as well as in Adguard itself. Also consider
-that the app and Adguard cannot use the same port for SSL.
+AdGuard Home allows the configuration of running DNS-over-HTTPS and
+DNS-over-TLS locally. If you configure these options please ensure to restart
+the app afterwards. Also to use DNS-over-HTTPS correctly please ensure to
+configure SSL on the app as well as in AdGuard Home itself. Also consider
+that the app and AdGuard Home cannot use the same port for SSL.
 
 ## Changelog & Releases
 


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Two small documentation fixes in `adguard/DOCS.md`:

- Documents the `notice` log level. The option schema accepts `list(trace|debug|info|notice|warning|error|fatal)?`, but `notice` was missing from the list of possible `log_level` values in the docs.
- Corrects the "Adguard" spelling to "AdGuard Home" in the Encryption Settings section, matching the product name used everywhere else in the documentation.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Added support for the `notice` log level option in configuration settings.
* Improved Encryption Settings documentation with enhanced formatting and consistency, particularly for DNS-over-HTTPS and DNS-over-TLS configuration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->