### PR TITLE
🐛 Pass --verbose to AdGuard Home in debug mode

### DIFF
--- a/adguard/rootfs/etc/s6-overlay/s6-rc.d/adguard/run
+++ b/adguard/rootfs/etc/s6-overlay/s6-rc.d/adguard/run
@@ -14,7 +14,7 @@ options+=(--work-dir /data/adguard)
 options+=(--no-check-update)
 
 if bashio::debug; then
-  option+=(--verbose)
+  options+=(--verbose)
 fi
 
 # RUN AdGuard Home server


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

The AdGuard Home run script builds the command line in an `options` array, but the debug branch appended the `--verbose` flag to a misspelled `option` array (singular) instead:

```bash
declare -a options
...
if bashio::debug; then
  option+=(--verbose)
fi

exec ./AdGuardHome "${options[@]}"
```

Because the flag landed in a throwaway variable, it was never passed to the AdGuard Home binary. Setting the app's `log_level` to `debug` or `trace` therefore never enabled AdGuard Home's own verbose logging, which is exactly what that setting is meant to do when troubleshooting.

This fixes the typo so `--verbose` is added to the `options` array that is actually executed.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed verbose mode not being correctly enabled for AdGuard when running in debug mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->