### PR TITLE
🐛 Fix AdGuard Home config schema version detection

### DIFF
--- a/adguard/rootfs/etc/s6-overlay/s6-rc.d/init-adguard/run
+++ b/adguard/rootfs/etc/s6-overlay/s6-rc.d/init-adguard/run
@@ -25,7 +25,7 @@ port=$(bashio::app.port "53/udp") \
 
 # Bump schema version in case this is an upgrade path
 schema_version=$(yq e '.schema_version // ""' "${CONFIG}")
-if bashio::var.has_value "${schema_version+}"; then
+if bashio::var.has_value "${schema_version}"; then
     if (( schema_version == 7 )); then
         # Clean up old interface bind formats
         yq --inplace e 'del(.dns.bind_host)' "${CONFIG}"


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

The config schema version detection in the AdGuard Home init script never worked, because of a stray `+` in a parameter expansion:

```bash
schema_version=$(yq e '.schema_version // ""' "${CONFIG}")
if bashio::var.has_value "${schema_version+}"; then
```

`${schema_version+}` is `${parameter+word}` expansion with an empty `word`. That substitutes the (empty) word whenever the variable is set, and nothing when it is unset, so it **always** expands to an empty string regardless of the actual schema version:

```
set to "8" -> []
empty       -> []
unset       -> []
```

`bashio::var.has_value` therefore always returned false and the detection always fell through to the `else` branch. The consequences:

- The schema 7 → 8 migration (`del(.dns.bind_host)` + bump to 8) never ran.
- The "below schema 7" upgrade warning and early exit never ran.
- A dummy `dns.bind_host = "127.0.0.1"` was written into the configuration on every start, even for current schema 8 configurations where `bind_host` is deprecated in favor of `bind_hosts`.

Dropping the stray `+` so the check reads `"${schema_version}"` restores the intended behavior: a current schema 8 config matches neither sub-condition and is left untouched, a missing schema still falls back to the dummy bind host, and the 7 → 8 and below-7 paths work again.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed how the AdGuard service detects configuration versions during startup initialization. This ensures existing configurations are properly recognized and handled during migration, preventing potential issues that could occur with configuration management during service updates and version upgrades. The improved detection mechanism enhances overall reliability of the upgrade process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->