### PR TITLE
🔧 Remove non-functional NGINX OCSP stapling

### DIFF
--- a/adguard/rootfs/etc/nginx/includes/resolver.conf
+++ b/adguard/rootfs/etc/nginx/includes/resolver.conf
@@ -1,1 +1,0 @@
-resolver %%dns_host%%;

--- a/adguard/rootfs/etc/nginx/includes/ssl_params.conf
+++ b/adguard/rootfs/etc/nginx/includes/ssl_params.conf
@@ -4,5 +4,3 @@ ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDS
 ssl_session_timeout  10m;
 ssl_session_cache shared:SSL:10m;
 ssl_session_tickets off;
-ssl_stapling on;
-ssl_stapling_verify on;


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

NGINX OCSP stapling was enabled in `ssl_params.conf` (included by the direct-access server when SSL is on):

```nginx
ssl_stapling on;
ssl_stapling_verify on;
```

OCSP stapling requires a `resolver` directive so NGINX can resolve the OCSP responder host. The only resolver definition in the repo lived in `includes/resolver.conf`, which was **never** `include`d anywhere, and its `%%dns_host%%` placeholder was never substituted by the init script. So stapling could never function, and NGINX logged `"no resolver defined to resolve <ocsp-host>"` warnings on every start with SSL/direct access enabled.

This removes the orphaned `resolver.conf` and the two `ssl_stapling` directives. This is dead, non-working configuration; TLS itself is unaffected.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Changes**
  * Removed DNS resolver configuration from Nginx settings.
  * Disabled SSL certificate stapling verification in SSL/TLS parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->