### PR TITLE
🌐 Add English configuration translations

### DIFF
--- a/adguard/translations/en.yaml
+++ b/adguard/translations/en.yaml
@@ -1,0 +1,35 @@
+---
+configuration:
+  log_level:
+    name: Log level
+    description: >-
+      Controls the level of log output by the app and can be changed to be
+      more or less verbose, which might be useful when you are dealing with
+      an unknown issue. Each level automatically includes the messages of a
+      more severe level.
+  ssl:
+    name: SSL
+    description: >-
+      Enables/Disables encrypted SSL (HTTPS) for direct access to the app.
+      This setting has no effect on the Ingress service.
+  certfile:
+    name: Certificate file
+    description: >-
+      The certificate file to use for SSL. The file must be stored in the
+      `/ssl/` directory.
+  keyfile:
+    name: Private key file
+    description: >-
+      The private key file to use for SSL. The file must be stored in the
+      `/ssl/` directory.
+  leave_front_door_open:
+    name: Leave front door open
+    description: >-
+      Disables authentication on AdGuard Home when enabled. We strongly
+      advise against enabling this, even on an internal network. Use at your
+      own risk!
+network:
+  53/udp:
+    description: DNS server port
+  80/tcp:
+    description: Web interface (not required for Ingress)


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

The `adguard/translations/` directory was empty, so the add-on shipped no configuration UI translations. As a result the options panel displayed the raw schema keys (for example `leave_front_door_open`) instead of friendly names and descriptions.

This adds a `translations/en.yaml` providing names and descriptions for every configuration option (`log_level`, `ssl`, `certfile`, `keyfile`, `leave_front_door_open`) plus the network port descriptions. The wording mirrors the existing option documentation in `DOCS.md`.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added English language translation strings for configuration and network settings. Includes labels for log levels, SSL certificate/key management, authentication controls, and descriptions for DNS and web interface services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->