### PR TITLE
🌐 Add Dutch configuration translations

### DIFF
--- a/adguard/translations/nl.yaml
+++ b/adguard/translations/nl.yaml
@@ -1,0 +1,33 @@
+---
+configuration:
+  log_level:
+    name: Logniveau
+    description: >-
+      Bepaalt hoe gedetailleerd de app logt. Een hoger detailniveau kan
+      helpen bij het onderzoeken van een probleem. Elk niveau bevat ook de
+      meldingen van de ernstigere niveaus.
+  ssl:
+    name: SSL
+    description: >-
+      Schakelt versleuteling (HTTPS) in of uit voor directe toegang tot de
+      app. Dit heeft geen invloed op toegang via Ingress.
+  certfile:
+    name: Certificaatbestand
+    description: >-
+      Het te gebruiken SSL-certificaatbestand. Plaats het bestand in de map
+      `/ssl/`.
+  keyfile:
+    name: Privésleutelbestand
+    description: >-
+      Het te gebruiken SSL-privésleutelbestand. Plaats het bestand in de map
+      `/ssl/`.
+  leave_front_door_open:
+    name: Voordeur open laten
+    description: >-
+      Schakelt de authenticatie van AdGuard Home uit. We raden dit sterk af,
+      zelfs op een intern netwerk. Gebruik op eigen risico!
+network:
+  53/udp:
+    description: DNS-serverpoort
+  80/tcp:
+    description: Webinterface (niet nodig voor Ingress)


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Adds `translations/nl.yaml` with Dutch names and descriptions for the add-on configuration options, so the configuration panel is localized for Dutch users.

The Dutch wording was reviewed by a native speaker and follows Home Assistant house style (informal address, concise phrasing) rather than a literal translation.

Scope note: this intentionally ships only Dutch (alongside the existing English). An earlier attempt to bulk machine-translate every Home Assistant language was dropped, because that output could not be quality-verified per language. Additional languages are welcome via follow-up PRs from native speakers.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/