### PR TITLE
🔒 Improve NGINX response headers

### DIFF
--- a/adguard/rootfs/etc/nginx/includes/proxy_params.conf
+++ b/adguard/rootfs/etc/nginx/includes/proxy_params.conf
@@ -11,5 +11,4 @@ proxy_set_header Host $http_host;
 proxy_set_header Upgrade $http_upgrade;
 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 proxy_set_header X-Forwarded-Proto $scheme;
-proxy_set_header X-NginX-Proxy true;
 proxy_set_header X-Real-IP $remote_addr;

--- a/adguard/rootfs/etc/nginx/includes/server_params.conf
+++ b/adguard/rootfs/etc/nginx/includes/server_params.conf
@@ -1,6 +1,5 @@
 root            /dev/null;
 server_name     $hostname;
 
-add_header X-Content-Type-Options nosniff;
-add_header X-XSS-Protection "1; mode=block";
-add_header X-Robots-Tag none;
+add_header X-Content-Type-Options nosniff always;
+add_header X-Robots-Tag none always;


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

A small cleanup of the NGINX headers used for the app's web interface:

- Removes the `X-XSS-Protection` header. It is deprecated, ignored by modern browsers, and explicitly discouraged (OWASP), since in some edge cases it can introduce vulnerabilities rather than prevent them.
- Adds the `always` parameter to the remaining security headers (`X-Content-Type-Options`, `X-Robots-Tag`) so they are also emitted on error responses (4xx/5xx), not just successful ones.
- Drops the non-standard, legacy `X-NginX-Proxy` request header, which serves no purpose.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Enhanced HTTP security headers to provide better protection against content-type sniffing and improve overall security posture.
  * Improved proxy configuration for more reliable forwarding of client request information.
  * Updated security headers to apply consistently across all server responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->