### PR TITLE
🚿 Tidy up NGINX service scripts

### DIFF
--- a/adguard/rootfs/etc/s6-overlay/s6-rc.d/nginx/finish
+++ b/adguard/rootfs/etc/s6-overlay/s6-rc.d/nginx/finish
@@ -1,4 +1,5 @@
 #!/command/with-contenv bashio
+# shellcheck shell=bash
 # ==============================================================================
 # Home Assistant Community App: AdGuard Home
 # Take down the S6 supervision tree when Nginx fails

--- a/adguard/rootfs/etc/s6-overlay/s6-rc.d/nginx/run
+++ b/adguard/rootfs/etc/s6-overlay/s6-rc.d/nginx/run
@@ -1,11 +1,12 @@
 #!/command/with-contenv bashio
+# shellcheck shell=bash
 # ==============================================================================
 # Home Assistant Community App: AdGuard Home
-# Runs the Nginx daemon
+# Runs the NGINX daemon
 # ==============================================================================
 
 # Wait for adguard to become available
-bashio::net.wait_for 45158 localhost 900
+bashio::net.wait_for 45158 127.0.0.1 900
 
-bashio::log.info "Starting NGinx..."
+bashio::log.info "Starting NGINX..."
 exec nginx


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Small tidy-up of the NGINX service scripts:

- Adds the `# shellcheck shell=bash` directive to `nginx/run` and `nginx/finish`, matching the other five service scripts in the add-on.
- Fixes the inconsistent "NGinx" casing to "NGINX" in the startup log line.
- Makes `nginx/run` wait on `127.0.0.1` instead of `localhost`, matching the address AdGuard Home actually binds to and the `discovery` service script (avoids any ambiguity if `localhost` resolves to `::1`).

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated NGINX startup readiness check to use correct localhost address.
  * Improved clarity of NGINX startup log messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->