### PR TITLE
Add ability to expose DNS-over-TLS port to configuration

### DIFF
--- a/adguard/config.yaml
+++ b/adguard/config.yaml
@@ -16,9 +16,11 @@ arch:
 init: false
 ports:
   53/udp: 53
+  853/tcp: null
   80/tcp: null
 ports_description:
   53/udp: DNS server port
+  853/tcp: DNS-over-TLS server port
   80/tcp: Web interface (Not required for Ingress)
 discovery:
   - adguard


### PR DESCRIPTION
# Proposed Changes

Add ability to expose DNS-over-TLS port to support Private DNS on Android devices.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation / Configuration**
  * Added an additional exposed port entry for `853/tcp` (DNS-over-TLS) in the configuration.
  * Updated the exposed ports documentation to describe `853/tcp` as the DNS-over-TLS server port, alongside the existing DNS server port (`53/udp`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->