### PR TITLE
Fix translations for network ports

### DIFF
--- a/adguard/translations/en.yaml
+++ b/adguard/translations/en.yaml
@@ -29,7 +29,5 @@ configuration:
       advise against enabling this, even on an internal network. Use at your
       own risk!
 network:
-  53/udp:
-    description: DNS server port
-  80/tcp:
-    description: Web interface (not required for Ingress)
+  53/udp: DNS server port
+  80/tcp: Web interface (not required for Ingress)

--- a/adguard/translations/nl.yaml
+++ b/adguard/translations/nl.yaml
@@ -27,7 +27,5 @@ configuration:
       Schakelt de authenticatie van AdGuard Home uit. We raden dit sterk af,
       zelfs op een intern netwerk. Gebruik op eigen risico!
 network:
-  53/udp:
-    description: DNS-serverpoort
-  80/tcp:
-    description: Webinterface (niet nodig voor Ingress)
+  53/udp: DNS-serverpoort
+  80/tcp: Webinterface (niet nodig voor Ingress)


### PR DESCRIPTION
# Proposed Changes

> This PR fixes the network port translations, which are currently not using the correct YAML schema.
> 
> Found due to the following warnings in the HA supervisor logs:
> ```WARNING (SyncWorker_0) [supervisor.store.data] Can't read translations from /data/apps/git/a0d7b954/adguard/translations/en.yaml - expected str for dictionary value @ data['network']['53/udp']```
>
> [HA docs for port translations](https://developers.home-assistant.io/docs/apps/configuration#port-description-translations)

## Related Issues

> none

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reformatted network port help text in English and Dutch translations for improved consistency and readability.
  * Preserved existing descriptions for the DNS server and web interface ports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->