### PR TITLE
👷 Replace Repology with Alpine CDN datasource for package pins

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,6 +6,12 @@
   "labels": ["dependencies", "no-stale"],
   "commitMessagePrefix": "⬆️",
   "commitMessageTopic": "{{depName}}",
+  "customDatasources": {
+    "alpine": {
+      "defaultRegistryUrlTemplate": "https://dl-cdn.alpinelinux.org/alpine/v3.24/main/x86_64/",
+      "format": "html"
+    }
+  },
   "customManagers": [
     {
       "customType": "regex",
@@ -25,8 +31,9 @@
         "\\s\\s(?<package>[a-z0-9][a-z0-9-_]+)=(?<currentValue>[a-z0-9-_.]+)\\s+"
       ],
       "versioningTemplate": "loose",
-      "datasourceTemplate": "repology",
-      "depNameTemplate": "alpine_3_24/{{package}}"
+      "datasourceTemplate": "custom.alpine",
+      "depNameTemplate": "alpine_3_24/{{package}}",
+      "extractVersionTemplate": "^{{{package}}}-(?<version>\\d.*)\\.apk$"
     },
     {
       "customType": "regex",
@@ -40,8 +47,16 @@
   ],
   "packageRules": [
     {
-      "matchDatasources": ["repology"],
+      "matchDatasources": ["custom.alpine"],
       "automerge": true
+    },
+    {
+      "description": "Packages that live in the Alpine community repository",
+      "matchDatasources": ["custom.alpine"],
+      "matchPackageNames": ["alpine_3_24/yq-go"],
+      "registryUrls": [
+        "https://dl-cdn.alpinelinux.org/alpine/v3.24/community/x86_64/"
+      ]
     },
     {
       "groupName": "App base image",


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Renovate's `repology` datasource has stopped resolving Alpine package pins across the hassio-addons org. Every `alpine_3_24/*` lookup returns `no-result`, so Alpine pins are no longer updated at all, and builds break whenever upstream moves a pinned package. Repology rate limits its `tools/project-by` endpoint hard, and every run resolves its packages through it.

This swaps that datasource for a custom one that reads the Alpine CDN directory listing directly, the same fix already landed on `app-ssh` in hassio-addons/app-ssh#1119:

- Adds a `custom.alpine` datasource pointing at `https://dl-cdn.alpinelinux.org/alpine/v3.24/main/x86_64/` with `format: html`, so each `href` in the directory listing becomes a version candidate.
- Points the Alpine custom manager at `custom.alpine` and adds `extractVersionTemplate` to pull the version out of the `.apk` filename. The leading `\d` in that pattern is what stops a package from matching a differently-named sibling package that shares its prefix.
- Switches the `repology` package rule over to `custom.alpine`.
- Adds a rule pointing `yq-go` at the Alpine **community** registry. Custom datasources use `registryStrategy: "first"`, so multiple `registryUrls` are not hunted and community packages would otherwise fail to resolve.

This add-on pins two packages, `nginx` and `yq-go`. Repository membership was derived from the `main` and `community` `APKINDEX` files rather than copied from `app-ssh`: `nginx` is in main and `yq-go` is in community. Both exist in an index, so there are no unbuildable pins here.

### Verification

A passing CI build proves nothing for this change, since it does not touch the `Dockerfile` and buildx serves the `apk` layer from cache, so no `apk add` runs. The evidence is a local Renovate dry run (`RENOVATE_PLATFORM=local`, `RENOVATE_DRY_RUN=lookup`) against this branch:

- `renovate-config-validator` passes.
- **0** occurrences of `Found no results`, and no lookup failures.
- **2** dependencies extracted, matching the 2 pins in the `Dockerfile`. Both resolved with a `fixedVersion` and an empty `warnings` array, and `yq-go` resolved through the community `registryUrl`.
- **0** updates found, which agrees with the `APKINDEX` files: `nginx 1.30.4-r1` and `yq-go 4.53.3-r0` are both current upstream. No stale pin is waiting to land once this merges.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Applies the same fix as hassio-addons/app-ssh#1119.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved automated dependency update handling for Alpine-based packages.
  - Alpine package versions are now detected more accurately from the official Alpine v3.24 repositories.
  - Eligible Alpine package updates can be merged automatically, helping keep supported packages current with less maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->