### PR TITLE
🐛 Fix non-existent bashio::warning calls in schema migration warning

### DIFF
--- a/adguard/rootfs/etc/s6-overlay/s6-rc.d/init-adguard/run
+++ b/adguard/rootfs/etc/s6-overlay/s6-rc.d/init-adguard/run
@@ -36,11 +36,11 @@ if bashio::var.has_value "${schema_version}"; then
     if (( schema_version < 7 )); then
         # Ensure dummy value exists so AdGuard doesn't kill itself during migration
         yq --inplace e '.dns.bind_host = "127.0.0.1"' "${CONFIG}"
-        bashio::warning
-        bashio::warning "AdGuard Home needs to update its configuration schema"
-        bashio::warning "you might need to restart the app once more to complete"
-        bashio::warning "the upgrade process."
-        bashio::warning
+        bashio::log.warning
+        bashio::log.warning "AdGuard Home needs to update its configuration schema"
+        bashio::log.warning "you might need to restart the app once more to complete"
+        bashio::log.warning "the upgrade process."
+        bashio::log.warning
         bashio::exit.ok
     fi
 else


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

`init-adguard/run` calls `bashio::warning` five times, but that function does not exist in bashio. The correct name is `bashio::log.warning`.

This surfaced while auditing the add-on for compatibility with bashio v0.19.0 in the base image. It is not a v0.19.0 regression: `bashio::warning` has never existed, and is absent from v0.17.5, v0.18.0, v0.18.1 and v0.19.0 alike. Every other `bashio::*` call in `rootfs` was cross-checked against the functions bashio v0.19.0 defines, and this was the only one that does not resolve.

The affected code path is the guard for users upgrading from an AdGuard Home config schema below version 7. Today that path emits `bashio::warning: command not found` five times instead of the intended warning, so the user is told nothing about needing to restart the add-on to finish the schema migration. The `bashio::exit.ok` that follows still runs, so the migration itself is unaffected, only the message the user needs to see is lost.

Beyond this, bashio v0.18.1 to v0.19.0 needs no changes here. That delta is limited to `lib/exit.sh` and `lib/log.sh`: exit functions now accept multiple message arguments like the log functions do, plus a fix for closed `LOG_FD 10` detection. The v0.18 `bashio::addon.*` to `bashio::app.*` rename was already handled in #691.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Follow-up to #691, which handled the bashio v0.18 rename.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated configuration upgrade warnings to use the current logging mechanism.
  * Improved compatibility and consistency of warning messages during schema upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->