### PR TITLE
🐛 Wait for host network before collecting AdGuard Home bind hosts

### DIFF
--- a/adguard/rootfs/etc/s6-overlay/s6-rc.d/init-adguard/run
+++ b/adguard/rootfs/etc/s6-overlay/s6-rc.d/init-adguard/run
@@ -6,6 +6,9 @@
 # Handles configuration
 # ==============================================================================
 readonly CONFIG="/data/adguard/AdGuardHome.yaml"
+readonly NETWORK_WAIT_SECONDS=300
+readonly NETWORK_POLL_SECONDS=5
+declare network_ready="false"
 declare schema_version
 declare -a interfaces
 declare -a hosts
@@ -47,6 +50,58 @@ else
     # No idea what the schema is, might be an old config?
     # Ensure dummy value exists so AdGuard doesn't kill itself during migration
     yq --inplace e '.dns.bind_host = "127.0.0.1"' "${CONFIG}"
+fi
+
+# Returns successfully as soon as any interface reports a usable IPv4 address.
+function has_usable_address() {
+    local interface
+    local host
+
+    for interface in $(bashio::network.interfaces); do
+        for host in $(bashio::network.ipv4_address "${interface}"); do
+            # 169.254.0.0/16 according to RFC 3927 -> Local link. Not usable.
+            if (( "${host%%.*}" == 169 )); then
+                continue
+            fi
+            return "${__BASHIO_EXIT_OK}"
+        done
+    done
+
+    return "${__BASHIO_EXIT_NOK}"
+}
+
+# Wait for the host network to become available.
+#
+# The bind hosts below are collected once, right now. On a (re)boot this app
+# can start before an interface has been handed its address, for example while
+# it is still waiting on a DHCP lease. An address that only shows up later is
+# never picked up, leaving AdGuard Home listening on localhost alone until the
+# app is restarted by hand.
+for (( waited = 0; waited < NETWORK_WAIT_SECONDS; waited += NETWORK_POLL_SECONDS )); do
+    if has_usable_address; then
+        network_ready="true"
+        break
+    fi
+
+    if (( waited == 0 )); then
+        bashio::log.info "Waiting for the host network to become available..."
+    fi
+
+    sleep "${NETWORK_POLL_SECONDS}"
+
+    # Network information is cached, so drop it before the next round.
+    # Without this, every retry re-reads the same empty answer instead of
+    # asking the Supervisor again.
+    bashio::cache.flush_all
+done
+
+if ! bashio::var.true "${network_ready}"; then
+    bashio::log.warning
+    bashio::log.warning "No usable IPv4 address found after ${NETWORK_WAIT_SECONDS} seconds."
+    bashio::log.warning "AdGuard Home will only listen on the addresses known"
+    bashio::log.warning "right now. If clients cannot reach it, restart this app"
+    bashio::log.warning "once the network is up."
+    bashio::log.warning
 fi
 
 # Collect IP addresses from interfaces

--- a/adguard/rootfs/etc/s6-overlay/s6-rc.d/init-adguard/run
+++ b/adguard/rootfs/etc/s6-overlay/s6-rc.d/init-adguard/run
@@ -60,7 +60,7 @@ function has_usable_address() {
     for interface in $(bashio::network.interfaces); do
         for host in $(bashio::network.ipv4_address "${interface}"); do
             # 169.254.0.0/16 according to RFC 3927 -> Local link. Not usable.
-            if (( "${host%%.*}" == 169 )); then
+            if [[ "${host}" == 169.254.* ]]; then
                 continue
             fi
             return "${__BASHIO_EXIT_OK}"
@@ -146,11 +146,8 @@ for host in "${hosts[@]}"; do
 
     if [[ "${host}" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
 
-      # IPv4
-      part="${host%%.*}"
-
       # 169.254.0.0/16 according to RFC 3927 -> Local link. Skip it
-      if (( part == 169 )); then
+      if [[ "${host}" == 169.254.* ]]; then
         continue
       fi
     fi


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Fixes the app coming up without listening on the network after a host reboot, most visibly after a Home Assistant OS update, leaving clients with no DNS until the app is restarted by hand.

`init-adguard` collects `dns.bind_hosts` by enumerating the interfaces and their addresses once, at startup, and writes the result into `AdGuardHome.yaml`. There is no wait and no retry. When the app starts before an interface has been handed its address, for example while it is still waiting on a DHCP lease, that address is simply not there to be found. AdGuard Home then binds to localhost and the Supervisor interface only, and never picks up the address that arrives moments later. This matches the logs in #704, and it explains both why a manual restart fixes it and why a DHCP reservation makes it more likely than a static address: the lease wait is what opens the window.

This adds a bounded wait for a usable IPv4 address before the enumeration runs. It is placed after the config schema migration path, so the early exit there is not delayed. If no usable address turns up within the timeout the app carries on rather than failing, but logs a warning explaining what happened and what to do about it. Link-local `169.254.0.0/16` addresses do not count as usable, matching how the enumeration below already treats them.

The non-obvious part is the `bashio::cache.flush_all` inside the loop. Bashio caches both the `network.info` blob and the per-interface `network.interface.<iface>.info` blob, so without dropping the cache each round the retry re-reads the same stale answer instead of asking the Supervisor again. See the verification below, where removing that single line turns the whole fix into a silent no-op.

### Verification

Tested against a harness that stubs the bashio network calls and reproduces its caching behaviour, since the failure only occurs during a real boot race:

- Address already present, the normal boot: no delay, no log output, the Supervisor is polled once. No cost in the common case.
- Address appears 3 seconds in, the reported failure: the wait retries and picks it up, Supervisor polled 4 times.
- Only a link-local `169.254.x` address: correctly not treated as usable, times out, warns, and continues instead of failing.
- Negative control, the same race with only the `bashio::cache.flush_all` call removed: the wait fails and the Supervisor is polled exactly once for the entire duration, confirming that the cache flush is what makes the retry real.

### Scope

This closes the startup race, which is what users are actually running into. It does not re-bind when an address changes while the app is already running, so the interface rename after an OS upgrade reported further down #704 still needs a restart. Handling that means reacting to network changes at runtime, which is a much larger change to this code path and is better kept separate.

The timeout is set to 300 seconds, in line with the existing `bashio::net.wait_for` calls elsewhere in this app. Worth noting that unlike those, this wait can genuinely never be satisfied on a host with no network at all, in which case startup is held for that long before continuing.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Fixes #704

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup reliability by waiting for a usable network address before configuring AdGuard Home.
  * Added a timeout and fallback behavior so startup continues even when network readiness is delayed.
  * Added warnings when no usable address is available within the wait period.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->